### PR TITLE
Inline-Style of WaitCursor

### DIFF
--- a/src/scss/_objects/wait-cursor.scss
+++ b/src/scss/_objects/wait-cursor.scss
@@ -28,6 +28,9 @@
       visibility: hidden;
       animation: none;
     }
+    &--inline {
+      display: inline-block;
+    }
   }
   .wait-cursor__spinner {
     border: 3px solid $wait-cursor-color;


### PR DESCRIPTION
This PR adds the CSS-class *wait-cursor__spinner--inline*, which is required for the inline-prop of the SmallWaitCursor of ChaynsComponents (https://github.com/TobitSoftware/chayns-components/commit/954aca10b399fae06d623f11bc44ab7dbc87ab82)