### PR TITLE
TagInput styles

### DIFF
--- a/src/scss/_color-default.scss
+++ b/src/scss/_color-default.scss
@@ -179,3 +179,7 @@ $file-input-color: map_get($colors1, 6);
 //gallery
 $gallery-deleteIcon-color: $color;
 $gallery-deleteIcon-backgroundColor: map_get($shades, 1);
+
+//tag input
+$cc__tag-color: map_get($colors1, 3);
+$cc__tag-selected-color: map_get($colors1, 4);

--- a/src/scss/_color-inverted.scss
+++ b/src/scss/_color-inverted.scss
@@ -176,3 +176,7 @@ $file-input-color: map_get($shades, 1);
 //gallery
 $gallery-deleteIcon-color: $color;
 $gallery-deleteIcon-backgroundColor: map_get($shades, 1);
+
+//tag input
+$cc__tag-color: map_get($colors1, 4);
+$cc__tag-selected-color: map_get($colors1, 5);

--- a/src/scss/_color-pure.scss
+++ b/src/scss/_color-pure.scss
@@ -178,3 +178,7 @@ $file-input-color: map_get($colors1, 6);
 //gallery
 $gallery-deleteIcon-color: $color;
 $gallery-deleteIcon-backgroundColor: map_get($shades, 1);
+
+//tag input
+$cc__tag-color: map_get($colors1, 3);
+$cc__tag-selected-color: map_get($colors1, 4);

--- a/src/scss/_color.scss
+++ b/src/scss/_color.scss
@@ -178,3 +178,7 @@ $file-input-color: map_get($colors1, 6);
 //gallery
 $gallery-deleteIcon-color: $color;
 $gallery-deleteIcon-backgroundColor: map_get($shades, 1);
+
+//tag input
+$cc__tag-color: map_get($colors1, 3);
+$cc__tag-selected-color: map_get($colors1, 4);

--- a/src/scss/_objects/_components/tag-input.scss
+++ b/src/scss/_objects/_components/tag-input.scss
@@ -1,0 +1,54 @@
+@import '../../_color.scss';
+
+$tag-height: 24px;
+
+.cc__tag-input {
+  display: flex;
+  flex-wrap: wrap;
+
+  -webkit-user-modify: read-only;
+  -webkit-appearance: none;
+
+  align-items: center;
+
+  .cc__tag-input__input {
+    margin: 5px 5px 0;
+
+    height: $tag-height;
+
+    flex-grow: 1;
+  }
+
+  .cc__tag-input__input input {
+    border: none;
+  }
+}
+
+.cc__tag {
+  display: inline-block;
+  background-color: $cc__tag-color;
+
+  padding: 0 6px;
+
+  margin: 5px 5px 0;
+
+  user-select: none;
+
+  transition: background-color 300ms;
+
+  &--selected {
+    background-color: $cc__tag-selected-color;
+  }
+
+  .icon {
+    color: $color;
+
+    padding-left: 6px;
+
+    opacity: 0.6;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+}

--- a/src/scss/chayns.scss
+++ b/src/scss/chayns.scss
@@ -52,3 +52,4 @@
 @import './_objects/_components/amount-control';
 @import './_objects/_components/calendar';
 @import './_objects/_components/contextmenu';
+@import './_objects/_components/tag-input';


### PR DESCRIPTION
This PR adds the CSS-class _cc__tag-input_ which is required for the TagInput component of ChaynsComponents ([TobitSoftware/chayns-components-tag_input](https://github.com/TobitSoftware/chayns-components/blob/4b81814e68c1b43b5f3ccbe6d22a1852c3869f63/src/react-chayns-tag_input/component/TagInput.jsx))