### PR TITLE
Fix overridden color

### DIFF
--- a/src/scss/_color-default.scss
+++ b/src/scss/_color-default.scss
@@ -95,8 +95,12 @@ $choosebutton-background-color: map_get($colors1, 2);
 $choosebutton-hover-background-color: map_get($colors1, 3);
 
 //contextmenu
-$contextMenuTriggerColor: map_get($colors1, 5);
-$contextMenuIconColor: map_get($colors1, 5);
+$contextmenu-color: #545454;
+$contextmenu-background-color: #FFFFFF;
+$contextmenu-hover-background-color: #F3F3F3;
+$contextmenu-border-color: rgba(0, 0, 0, .1);
+$contextmenu-trigger-color: map_get($colors1, 5);
+$contextmenu-icon-color: map_get($colors1, 5);
 
 //select
 $select-hover-icon-color: map_get($colors1, 4);

--- a/src/scss/_color-inverted.scss
+++ b/src/scss/_color-inverted.scss
@@ -94,8 +94,12 @@ $choosebutton-background-color: map_get($colors2, 3);
 $choosebutton-hover-background-color: map_get($colors2, 2);
 
 //contextmenu
-$contextMenuTriggerColor: map_get($shades, 5);
-$contextMenuIconColor: map_get($colors1, 5);
+$contextmenu-color: #545454;
+$contextmenu-background-color: #FFFFFF;
+$contextmenu-hover-background-color: #F3F3F3;
+$contextmenu-border-color: rgba(0, 0, 0, .1);
+$contextmenu-trigger-color: map_get($shades, 5);
+$contextmenu-icon-color: map_get($colors1, 5);
 
 //select
 $select-background-color: map_get($colors2, 3);

--- a/src/scss/_color-pure.scss
+++ b/src/scss/_color-pure.scss
@@ -94,8 +94,12 @@ $choosebutton-background-color: map_get($colors1, 2);
 $choosebutton-hover-background-color: map_get($colors1, 3);
 
 //contextmenu
-$contextMenuTriggerColor: map_get($colors1, 5);
-$contextMenuIconColor: map_get($colors1, 5);
+$contextmenu-color: #545454;
+$contextmenu-background-color: #FFFFFF;
+$contextmenu-hover-background-color: #F3F3F3;
+$contextmenu-border-color: rgba(0, 0, 0, .1);
+$contextmenu-trigger-color: map_get($colors1, 5);
+$contextmenu-icon-color: map_get($colors1, 5);
 
 //select
 $select-hover-icon-color: map_get($colors1, 4);

--- a/src/scss/_color.scss
+++ b/src/scss/_color.scss
@@ -94,8 +94,12 @@ $choosebutton-background-color: map_get($colors1, 2);
 $choosebutton-hover-background-color: map_get($colors1, 3);
 
 //contextmenu
-$contextMenuTriggerColor: map_get($colors1, 5);
-$contextMenuIconColor: map_get($colors1, 5);
+$contextmenu-color: #545454;
+$contextmenu-background-color: #FFFFFF;
+$contextmenu-hover-background-color: #F3F3F3;
+$contextmenu-border-color: rgba(0, 0, 0, .1);
+$contextmenu-trigger-color: map_get($colors1, 5);
+$contextmenu-icon-color: map_get($colors1, 5);
 
 //select
 $select-hover-icon-color: map_get($colors1, 4);

--- a/src/scss/_objects/_components/contextmenu.scss
+++ b/src/scss/_objects/_components/contextmenu.scss
@@ -1,28 +1,25 @@
 @import '../../_color';
 
-$border: 1px solid rgba(0, 0, 0, .1);
-$background-color: #fff;
-$color: #545454;
-$hover-background-color: #f3f3f3;
+$contextmenu-border: 1px solid $contextmenu-border-color;
 
 .context-menu {
   position: absolute;
-  background-color: $background-color;
+  background-color: $contextmenu-background-color;
   z-index: 900;
   opacity: 0;
   transition: opacity 0.35s ease-in-out;
   box-shadow: 1px 3px 8px rgba(0, 0, 0, .3);
-  border: $border;
-  color: $color;
+  border: $contextmenu-border;
+  color: $contextmenu-color;
   &:after {
     content: "";
     width: 14px;
     height: 14px;
     position: absolute;
-    background-color: $background-color;
+    background-color: $contextmenu-background-color;
     box-shadow: -2px -2px 5px rgba(0, 0, 0, .05);
-    border-top: $border;
-    border-left: $border;
+    border-top: $contextmenu-border;
+    border-left: $contextmenu-border;
     z-index: -1;
   }
   &__children {
@@ -30,7 +27,7 @@ $hover-background-color: #f3f3f3;
       text-align: center;
       font-size: 18px;
       cursor: pointer;
-      color: $contextMenuTriggerColor;
+      color: $contextmenu-trigger-color;
       display: flex;
       flex-direction: column;
       justify-content: center;
@@ -41,14 +38,14 @@ $hover-background-color: #f3f3f3;
     cursor: pointer;
     display: flex;
     &:hover {
-      background-color: $hover-background-color;
+      background-color: $contextmenu-hover-background-color;
     }
     &__icon {
       width: 20px;
       margin: 0 8px 0 3px;
       text-align: center;
       flex: 0 0 auto;
-      color: $contextMenuIconColor;
+      color: $contextmenu-icon-color;
     }
     &__text {
       white-space: nowrap;


### PR DESCRIPTION
This PR should fixes a problem that causes the $color-variable to be overridden by the $color variable of the context-menu.
To follow the conventions, the color-variables used by context-menu were moved to the _color-* files and renamed.