### PR TITLE
Animation of accordion-head-right

### DIFF
--- a/src/scss/_objects/_components/accordion.scss
+++ b/src/scss/_objects/_components/accordion.scss
@@ -265,3 +265,65 @@
     white-space: normal;
   }
 }
+
+.accordion__head__right {
+  overflow: hidden;
+
+  .right--background {
+    &-appear, &-enter, &-exit {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      transition: opacity 0.5s ease;
+      will-change: opacity;
+    }
+
+    &-enter, &-appear {
+      right: 5px;
+      opacity: 0;
+
+      &-active {
+        opacity: 1;
+      }
+    }
+
+    &-exit {
+      position: absolute;
+      right: 5px;
+      top: 50%;
+      transform: translateY(-50%);
+      opacity: 1;
+
+      &-active {
+        opacity: 0;
+      }
+    }
+  }
+
+  .right--foreground {
+    &-appear, &-enter, &-exit {
+      transition: transform 0.5s, opacity 0.5s ease;
+      will-change: opacity;
+    }
+
+    &-enter, &-appear {
+      opacity: 0;
+      transform: translateX(150%);
+
+      &-active {
+        transform: translateX(0);
+        opacity: 1;
+      }
+    }
+
+    &-exit {
+      opacity: 1;
+      transform: translateX(0%);
+
+      &-active {
+        opacity: 0;
+        transform: translateX(150%);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new animation to the right site of the accordion-head section (used for Badge, Input, ContextMenu). It is required by chayns-components [feature/improve-badge](https://github.com/TobitSoftware/chayns-components/blob/99a52289fff4ec01a0eeb47ecdce1bb53b3102b7/src/react-chayns-accordion/component/AccordionHeadRight.jsx).