### PR TITLE
Slider-Component inside IE11

### DIFF
--- a/src/scss/_objects/_components/slider.scss
+++ b/src/scss/_objects/_components/slider.scss
@@ -20,6 +20,8 @@
         flex-direction: row;
 
         &__track {
+          left: 50%;
+          transform: translate(-50%, -50%);
           width: 8px;
           height: 100%;
 
@@ -30,7 +32,8 @@
         }
 
         &__thumb {
-          transform: translateY(-15px);
+          left: 50%;
+          transform: translate(-50%, -15px);
         }
       }
     }
@@ -59,11 +62,13 @@
     justify-content: center;
 
     &__track {
+      top: 50%;
       position: absolute;
       overflow: hidden;
       border-radius: 20px;
       height: 8px;
       width: 100%;
+      transform: translateY(-50%);
       background-color: $slider-track-background-color;
       cursor: pointer;
 
@@ -76,11 +81,12 @@
 
     &__thumb {
       position: absolute;
+      top: 50%;
       width: 30px;
       height: 30px;
       z-index: 10;
       padding: 5px;
-      transform: translateX(-15px);
+      transform: translate(-15px, -50%);
       cursor: pointer;
 
       &__dot {


### PR DESCRIPTION
The thumbs of the slider-component are rendered outside the track (in IE11). This PR uses absolute positioning to fix this.