### PR TITLE
Bubble-Component inside IE11

### DIFF
--- a/src/scss/_objects/_components/bubble.scss
+++ b/src/scss/_objects/_components/bubble.scss
@@ -11,10 +11,10 @@
 
   /** 0 = top right, 1 = bottom right, 2 = bottom left, 3 = top left */
   &--position0 { // top right
-    transform: translate(calc(-100% + 23px), -30px);
+    transform: translate(-100%, -30px) translateX(23px);
 
     &.cc__bubble--active {
-      transform: translate(calc(-100% + 23px), -10px);
+      transform: translate(-100%, -10px) translateX(23px);
     }
 
     .cc__bubble__overlay {
@@ -30,10 +30,10 @@
   }
 
   &--position1 { // bottom right
-    transform: translate(calc(-100% + 23px), -20px);
+    transform: translate(-100%, -20px) translateX(23px);
 
     &.cc__bubble--active {
-      transform: translate(calc(-100% + 23px), 0);
+      transform: translate(-100%, 0) translateX(23px);
     }
 
     .cc__bubble__overlay {


### PR DESCRIPTION
The bubble-component was positioned wrong, when using TOP_LEFT or BOTTOM_LEFT positioning. This is caused by calc() inside translate(). To prevent this the translate's could be chained.