### PR TITLE
PersonFinder-Component inside IE11

### DIFF
--- a/src/scss/_objects/_components/person-finder.scss
+++ b/src/scss/_objects/_components/person-finder.scss
@@ -60,6 +60,7 @@
         padding-left: 10px;
         line-height: 1.2;
         vertical-align: text-top;
+        flex-basis: 100%;
 
         .title {
           display: flex;


### PR DESCRIPTION
The text inside the PersonFinder-suggestion box are truncated inside the IE instead of wrapped (line break). This PR should fix this by setting a flex-basis of 100%.