### PR TITLE
Fix checkbox position without labelcontent

### DIFF
--- a/src/scss/_objects/_forms/checkbox.scss
+++ b/src/scss/_objects/_forms/checkbox.scss
@@ -13,6 +13,7 @@
     padding-left: 20px;
 
     line-height: calc(15px * #{$base-line-height});
+    min-height: calc(15px * #{$base-line-height});
     vertical-align: middle;
 
     &:before,


### PR DESCRIPTION
Force the label's minial height to be equal to the line-height. This prevents the checkbox from having no height, eg. when no label-content was set, which results in it moving out of line.
This does not change the label's behavior with content.