### PR TITLE
Fix sharingbar icons not centered

### DIFF
--- a/src/scss/_objects/_components/sharing-bar.scss
+++ b/src/scss/_objects/_components/sharing-bar.scss
@@ -1,9 +1,11 @@
+@import '../../_config';
+
 // @deprecated
 .sharing-bar__item-list {
   text-align: right;
 
   .sharing-bar__item {
-    width: 35px;
+    width: calc(#{$base-font-size} + 24px);
     margin-left: 5px;
   }
 }


### PR DESCRIPTION
Currently, the content of the sharingbar-buttons is up to 39px wide. 24px padding, 1em(15px) icon-size. Since the button only has a width of 35px some icons are 4px off-center.

This change ensures that the button are wide enough by using the base-font-size(15px) + the button padding(24px).