### PR TITLE
:bug: Fix bug where nested ListItems would get shown as open

### DIFF
--- a/src/scss/_objects/_components/lists.scss
+++ b/src/scss/_objects/_components/lists.scss
@@ -18,7 +18,7 @@
       background-color: $accordion-hover-background-color;
     }
 
-    &--clickable .list-item__header {
+    &--clickable > .list-item__header {
       cursor: pointer;
     }
 
@@ -113,7 +113,7 @@
       padding: 9px 18px 9px 29px;
     }
 
-    &--expanded {
+    &--expanded > .list-item__header {
       .list-item__titles {
         font-weight: bolder;
       }


### PR DESCRIPTION
Limit the selector to the list-item__header element when it is a direct child of list-item--expanded/--clickable, so ListItems further down the tree won't be affected by the upper state.